### PR TITLE
Make work with Gradle 4

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,4 +1,4 @@
-== Gradle Addon for JBoss Forge 2
+== Gradle Addon for JBoss Forge 3
 :idprefix: id_ 
 
 image:https://travis-ci.org/forge/addon-gradle.svg?branch=master["Build Status", link="https://travis-ci.org/forge/addon-gradle"]

--- a/impl-projects/src/main/java/org/jboss/forge/addon/gradle/projects/GradleFacetImpl.java
+++ b/impl-projects/src/main/java/org/jboss/forge/addon/gradle/projects/GradleFacetImpl.java
@@ -6,7 +6,12 @@
  */
 package org.jboss.forge.addon.gradle.projects;
 
-import org.gradle.jarjar.com.google.common.collect.Maps;
+import java.io.File;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.gradle.internal.impldep.com.google.common.collect.Maps;
 import org.jboss.forge.addon.configuration.Configuration;
 import org.jboss.forge.addon.facets.AbstractFacet;
 import org.jboss.forge.addon.gradle.parser.GradleSourceUtil;
@@ -15,13 +20,13 @@ import org.jboss.forge.addon.gradle.projects.model.GradleModelLoadUtil;
 import org.jboss.forge.addon.gradle.projects.model.GradleModelMergeUtil;
 import org.jboss.forge.addon.gradle.projects.model.GradleProfile;
 import org.jboss.forge.addon.projects.Project;
-import org.jboss.forge.addon.resource.*;
+import org.jboss.forge.addon.resource.FileResource;
+import org.jboss.forge.addon.resource.Resource;
+import org.jboss.forge.addon.resource.ResourceFactory;
+import org.jboss.forge.addon.resource.ResourceFilter;
+import org.jboss.forge.addon.resource.WriteableResource;
 import org.jboss.forge.furnace.util.OperatingSystemUtils;
 import org.jboss.forge.roaster.model.util.Strings;
-
-import javax.inject.Inject;
-import java.io.File;
-import java.util.Map;
 
 /**
  * @author Adam Wyłuda

--- a/impl-projects/src/main/java/org/jboss/forge/addon/gradle/projects/facets/GradleDependencyFacet.java
+++ b/impl-projects/src/main/java/org/jboss/forge/addon/gradle/projects/facets/GradleDependencyFacet.java
@@ -14,8 +14,8 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import org.gradle.jarjar.com.google.common.collect.Lists;
-import org.gradle.jarjar.com.google.common.collect.Sets;
+import org.gradle.internal.impldep.com.google.common.collect.Lists;
+import org.gradle.internal.impldep.com.google.common.collect.Sets;
 import org.jboss.forge.addon.dependencies.Coordinate;
 import org.jboss.forge.addon.dependencies.Dependency;
 import org.jboss.forge.addon.dependencies.DependencyQuery;

--- a/impl-projects/src/main/java/org/jboss/forge/addon/gradle/projects/facets/GradleJavaSourceFacet.java
+++ b/impl-projects/src/main/java/org/jboss/forge/addon/gradle/projects/facets/GradleJavaSourceFacet.java
@@ -9,7 +9,7 @@ package org.jboss.forge.addon.gradle.projects.facets;
 import java.io.File;
 import java.util.List;
 
-import org.gradle.jarjar.com.google.common.collect.Lists;
+import org.gradle.internal.impldep.com.google.common.collect.Lists;
 import org.jboss.forge.addon.facets.AbstractFacet;
 import org.jboss.forge.addon.facets.constraints.FacetConstraint;
 import org.jboss.forge.addon.facets.constraints.FacetConstraints;

--- a/impl-projects/src/main/java/org/jboss/forge/addon/gradle/projects/facets/GradlePackagingFacet.java
+++ b/impl-projects/src/main/java/org/jboss/forge/addon/gradle/projects/facets/GradlePackagingFacet.java
@@ -6,7 +6,11 @@
  */
 package org.jboss.forge.addon.gradle.projects.facets;
 
-import org.gradle.jarjar.com.google.common.collect.Lists;
+import java.io.PrintStream;
+import java.util.Collections;
+import java.util.List;
+
+import org.gradle.internal.impldep.com.google.common.collect.Lists;
 import org.jboss.forge.addon.facets.AbstractFacet;
 import org.jboss.forge.addon.facets.constraints.FacetConstraint;
 import org.jboss.forge.addon.facets.constraints.FacetConstraints;
@@ -19,10 +23,6 @@ import org.jboss.forge.addon.projects.building.BuildResult;
 import org.jboss.forge.addon.projects.building.ProjectBuilder;
 import org.jboss.forge.addon.projects.facets.PackagingFacet;
 import org.jboss.forge.addon.resource.Resource;
-
-import java.io.PrintStream;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * @author Adam Wyłuda

--- a/impl-projects/src/main/java/org/jboss/forge/addon/gradle/projects/facets/GradleResourcesFacet.java
+++ b/impl-projects/src/main/java/org/jboss/forge/addon/gradle/projects/facets/GradleResourcesFacet.java
@@ -8,7 +8,7 @@ package org.jboss.forge.addon.gradle.projects.facets;
 
 import java.util.List;
 
-import org.gradle.jarjar.com.google.common.collect.Lists;
+import org.gradle.internal.impldep.com.google.common.collect.Lists;
 import org.jboss.forge.addon.facets.AbstractFacet;
 import org.jboss.forge.addon.facets.constraints.FacetConstraint;
 import org.jboss.forge.addon.facets.constraints.FacetConstraints;

--- a/impl/src/main/java/org/jboss/forge/addon/gradle/parser/GradleSourceUtil.java
+++ b/impl/src/main/java/org/jboss/forge/addon/gradle/parser/GradleSourceUtil.java
@@ -9,9 +9,9 @@ package org.jboss.forge.addon.gradle.parser;
 import java.util.List;
 import java.util.Map;
 
-import org.gradle.jarjar.com.google.common.base.Joiner;
-import org.gradle.jarjar.com.google.common.collect.Lists;
-import org.gradle.jarjar.com.google.common.collect.Maps;
+import org.gradle.internal.impldep.com.google.common.base.Joiner;
+import org.gradle.internal.impldep.com.google.common.collect.Lists;
+import org.gradle.internal.impldep.com.google.common.collect.Maps;
 import org.jboss.forge.addon.gradle.projects.exceptions.UnremovableElementException;
 import org.jboss.forge.addon.gradle.projects.model.GradleDependency;
 import org.jboss.forge.addon.gradle.projects.model.GradleDependencyBuilder;

--- a/impl/src/main/java/org/jboss/forge/addon/gradle/parser/InvocationWithClosure.java
+++ b/impl/src/main/java/org/jboss/forge/addon/gradle/parser/InvocationWithClosure.java
@@ -10,9 +10,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.gradle.jarjar.com.google.common.base.Optional;
-import org.gradle.jarjar.com.google.common.collect.ImmutableList;
-import org.gradle.jarjar.com.google.common.collect.Maps;
+import org.gradle.internal.impldep.com.google.common.base.Optional;
+import org.gradle.internal.impldep.com.google.common.collect.ImmutableList;
+import org.gradle.internal.impldep.com.google.common.collect.Maps;
+
 
 /**
  * Represents invocations of a method which takes closure as a parameter.

--- a/impl/src/main/java/org/jboss/forge/addon/gradle/parser/InvocationWithMap.java
+++ b/impl/src/main/java/org/jboss/forge/addon/gradle/parser/InvocationWithMap.java
@@ -8,7 +8,8 @@ package org.jboss.forge.addon.gradle.parser;
 
 import java.util.Map;
 
-import org.gradle.jarjar.com.google.common.collect.ImmutableMap;
+import org.gradle.internal.impldep.com.google.common.collect.ImmutableMap;
+
 
 /**
  * Represents invocations of a method which takes map as a parameter.

--- a/impl/src/main/java/org/jboss/forge/addon/gradle/parser/SimpleGroovyParser.java
+++ b/impl/src/main/java/org/jboss/forge/addon/gradle/parser/SimpleGroovyParser.java
@@ -30,10 +30,10 @@ import org.codehaus.groovy.ast.stmt.BlockStatement;
 import org.codehaus.groovy.ast.stmt.ExpressionStatement;
 import org.codehaus.groovy.ast.stmt.Statement;
 import org.codehaus.groovy.control.SourceUnit;
-import org.gradle.jarjar.com.google.common.base.Optional;
-import org.gradle.jarjar.com.google.common.base.Preconditions;
-import org.gradle.jarjar.com.google.common.collect.Lists;
-import org.gradle.jarjar.com.google.common.collect.Maps;
+import org.gradle.internal.impldep.com.google.common.base.Optional;
+import org.gradle.internal.impldep.com.google.common.base.Preconditions;
+import org.gradle.internal.impldep.com.google.common.collect.Lists;
+import org.gradle.internal.impldep.com.google.common.collect.Maps;
 
 /**
  * This is a minimal groovy parser necessary to obtain information about gradle project. It can create method invocation

--- a/impl/src/main/java/org/jboss/forge/addon/gradle/parser/SourceUtil.java
+++ b/impl/src/main/java/org/jboss/forge/addon/gradle/parser/SourceUtil.java
@@ -10,8 +10,9 @@ import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.gradle.jarjar.com.google.common.base.Optional;
-import org.gradle.jarjar.com.google.common.base.Preconditions;
+import org.gradle.internal.impldep.com.google.common.base.Optional;
+import org.gradle.internal.impldep.com.google.common.base.Preconditions;
+
 
 /**
  * @author Adam Wyłuda

--- a/impl/src/main/java/org/jboss/forge/addon/gradle/projects/GradleManagerImpl.java
+++ b/impl/src/main/java/org/jboss/forge/addon/gradle/projects/GradleManagerImpl.java
@@ -13,7 +13,7 @@ import java.io.PrintStream;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
-import org.gradle.jarjar.com.google.common.collect.Lists;
+import org.gradle.internal.impldep.com.google.common.collect.Lists;
 import org.gradle.tooling.BuildLauncher;
 import org.gradle.tooling.GradleConnectionException;
 import org.gradle.tooling.GradleConnector;

--- a/impl/src/main/java/org/jboss/forge/addon/gradle/projects/model/GradleModelLoadUtil.java
+++ b/impl/src/main/java/org/jboss/forge/addon/gradle/projects/model/GradleModelLoadUtil.java
@@ -11,8 +11,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.gradle.jarjar.com.google.common.collect.Lists;
-import org.gradle.jarjar.com.google.common.collect.Maps;
+import org.gradle.internal.impldep.com.google.common.collect.Lists;
+import org.gradle.internal.impldep.com.google.common.collect.Maps;
 import org.jboss.forge.addon.gradle.parser.GradleSourceUtil;
 import org.jboss.forge.furnace.util.Strings;
 import org.jboss.forge.parser.xml.Node;

--- a/impl/src/main/java/org/jboss/forge/addon/gradle/projects/model/GradleModelMergeUtil.java
+++ b/impl/src/main/java/org/jboss/forge/addon/gradle/projects/model/GradleModelMergeUtil.java
@@ -10,8 +10,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.gradle.jarjar.com.google.common.collect.Lists;
-import org.gradle.jarjar.com.google.common.collect.Maps;
+import org.gradle.internal.impldep.com.google.common.collect.Lists;
+import org.gradle.internal.impldep.com.google.common.collect.Maps;
 import org.jboss.forge.addon.gradle.parser.GradleSourceUtil;
 import org.jboss.forge.furnace.util.Strings;
 

--- a/impl/src/main/resources/forgeOutput.gradle
+++ b/impl/src/main/resources/forgeOutput.gradle
@@ -211,6 +211,7 @@ allprojects {
     
         outputInc '<forgeOutput>'
         outputProject project
+        /*
         projectDir.eachFileMatch(groovy.io.FileType.FILES, {
             it.matches('^[a-zA-Z0-9]+-profile\\.gradle$')
         }, {
@@ -232,6 +233,7 @@ allprojects {
             outputProject project
             outputDec '</profile>'
         })
+        */
         outputDec '</forgeOutput>'
     
         outputFile.close()

--- a/impl/src/test/java/org/jboss/forge/addon/gradle/parser/GradleSourceUtilTest.java
+++ b/impl/src/test/java/org/jboss/forge/addon/gradle/parser/GradleSourceUtilTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.fail;
 import java.util.List;
 import java.util.Map;
 
-import org.gradle.jarjar.com.google.common.collect.Lists;
+import org.gradle.internal.impldep.com.google.common.collect.Lists;
 import org.jboss.forge.addon.gradle.projects.exceptions.UnremovableElementException;
 import org.jboss.forge.addon.gradle.projects.model.GradleDependency;
 import org.jboss.forge.addon.gradle.projects.model.GradleDependencyBuilder;

--- a/impl/src/test/java/org/jboss/forge/addon/gradle/parser/SimpleGroovyParserTest.java
+++ b/impl/src/test/java/org/jboss/forge/addon/gradle/parser/SimpleGroovyParserTest.java
@@ -6,12 +6,14 @@
  */
 package org.jboss.forge.addon.gradle.parser;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Map;
 
-import org.gradle.jarjar.com.google.common.base.Optional;
+import org.gradle.internal.impldep.com.google.common.base.Optional;
 import org.junit.Test;
 
 /**

--- a/impl/src/test/java/org/jboss/forge/addon/gradle/projects/model/GradleModelLoadUtilTest.java
+++ b/impl/src/test/java/org/jboss/forge/addon/gradle/projects/model/GradleModelLoadUtilTest.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import org.gradle.jarjar.com.google.common.collect.Maps;
+import org.gradle.internal.impldep.com.google.common.collect.Maps;
 import org.jboss.forge.furnace.util.Streams;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/impl/src/test/java/org/jboss/forge/addon/gradle/projects/model/GradleModelMergeUtilTest.java
+++ b/impl/src/test/java/org/jboss/forge/addon/gradle/projects/model/GradleModelMergeUtilTest.java
@@ -6,11 +6,12 @@
  */
 package org.jboss.forge.addon.gradle.projects.model;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Set;
 
-import org.gradle.jarjar.com.google.common.collect.Sets;
+import org.gradle.internal.impldep.com.google.common.collect.Sets;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
    </repositories>
 
    <properties>
-      <version.forge>3.0.0.Beta2</version.forge>
-      <version.furnace>2.23.0.Final</version.furnace>
+      <version.forge>3.9.1.Final</version.forge>
+      <version.furnace>2.28.2.Final</version.furnace>
       <maven.compiler.target>1.8</maven.compiler.target>
       <maven.compiler.source>1.8</maven.compiler.source>
       <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
@@ -71,7 +71,7 @@
          <dependency>
             <groupId>org.gradle</groupId>
             <artifactId>gradle-tooling-api</artifactId>
-            <version>1.11</version>
+            <version>4.10</version>
          </dependency>
          <dependency>
             <groupId>org.codehaus.groovy</groupId>

--- a/tests/src/test/java/org/jboss/forge/addon/gradle/projects/GradleFacetTest.java
+++ b/tests/src/test/java/org/jboss/forge/addon/gradle/projects/GradleFacetTest.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import org.gradle.jarjar.com.google.common.collect.Lists;
+import org.gradle.internal.impldep.com.google.common.collect.Lists;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.forge.addon.gradle.parser.GradleSourceUtil;


### PR DESCRIPTION
The addon was not working for me on Gradle 4 and so I made these changes to it in a working state again. Changes
- Upgraded gradle-tooling-api to latest Gradle 4.10 version
- Internally/shaded apis that are used from gradle-tooling-api have been moved to a different package; thats why so many imports/java-files have changed.
- I commented out the handling for profiles in forgeOutput.gradle. This gives an exception on allDependencies.clear() as this seems to be a read-only collection by now. Actually, this is the main reason why creating a gradle-project from Forge does not work; it has the -profiles file and that will brake all operations of the addon. I am not sure if it is even worth to reactivate this profile-handling as I don't think there is the need to replicate a mechanism like profiles in gradle. Maybe this can be dropped at all?
